### PR TITLE
Copilot/vscode1755480678420

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ _downloads/
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
-
+data/
 
 # Installer logs
 pip-log.txt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "."
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,9 +1,9 @@
 # ETL Pipeline Global Configuration
 # This is the main configuration file for the ETL pipeline
 workspaces:
-  downloads: ./downloads
-  staging_gdb: ./staging.gdb
-  sde_conn: C:/path/to/your.sde
+  downloads: .data/downloads
+  staging_gdb: .data/staging/staging.gdb
+  sde_conn: .data/connections/prod.sde
 # geoprocess:
 #   enabled: false
 # Environment settings (can be overridden by ETL_ENVIRONMENT variable)
@@ -36,11 +36,11 @@ retry:
 
 # File paths configuration
 paths:
-  download: "downloads"
-  staging: "staging"
-  output: "output"
-  temp: "temp"
-  logs: "logs"
+  download: ".data/downloads"
+  staging: ".data/ staging"
+  output: ".data/output"
+  temp: ".data/temp"
+  logs: ".logs"
 
 # Data processing configuration
 processing:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -137,7 +137,7 @@ global_ogc_bbox:
 ogc_api_delay: 0.1  # Seconds between requests (default: 0.1)
 
 # SDE loading settings
-sde_connection_file: "data/connections/prod.sde"
+sde_connection_file: ".data/connections/prod.sde"  # Updated to match new workspace structure
 sde_schema: "GNG"  # Schema prefix for datasets
 sde_dataset_pattern: "Underlag_{authority}"  # Pattern for dataset names
 sde_load_strategy: "truncate_and_load"  # Options: "truncate_and_load", "replace", "append"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -37,7 +37,7 @@ retry:
 # File paths configuration
 paths:
   download: ".data/downloads"
-  staging: ".data/ staging"
+  staging: ".data/staging"
   output: ".data/output"
   temp: ".data/temp"
   logs: ".logs"

--- a/etl/load_sde.py
+++ b/etl/load_sde.py
@@ -9,6 +9,10 @@ def run(cfg):
             continue
         src = f'{cfg["workspaces"]["staging_gdb"]}/{s["out_name"]}'
         dest = f'{sde}/{s["out_name"]}'   # keep same name for now
+        # If the source in the staging GDB doesn't exist, skip gracefully.
+        if not arcpy.Exists(src):
+            logging.warning(f"[LOAD] Source missing in staging, skipping: {src}")
+            continue
         if not arcpy.Exists(dest):
             # first time: create empty dest by copying schema
             arcpy.management.CreateFeatureclass(sde, s["out_name"], geometry_type=arcpy.Describe(src).shapeType, template=src, spatial_reference=arcpy.Describe(src).spatialReference)

--- a/etl/stage_files.py
+++ b/etl/stage_files.py
@@ -31,7 +31,12 @@ def _import_shapefile(shp_path: Path, cfg, out_name: str) -> bool:
         except Exception:
             # best-effort delete; continue to attempt import
             logging.debug(f"[STAGE] Could not delete existing {out_fc} before import")
-        arcpy.conversion.FeatureClassToFeatureClass(str(shp_path), out_fc.rsplit('/', 1)[0], out_fc.rsplit('/', 1)[1])
+        out_fc_path = Path(out_fc)
+        arcpy.conversion.FeatureClassToFeatureClass(
+            str(shp_path),
+            str(out_fc_path.parent),
+            out_fc_path.name
+        )
         logging.info(f"[STAGE] Imported shapefile {shp_path} -> {out_fc}")
         return True
     except Exception as e:

--- a/etl/stage_files.py
+++ b/etl/stage_files.py
@@ -53,7 +53,8 @@ def _import_gpkg(gpkg_path: Path, cfg, out_name: str, layer_name: str | None = N
         else:
             # ArcPy can reference gpkg with layer syntax if needed; try to copy first layer
             src = str(gpkg_path)
-        arcpy.conversion.FeatureClassToFeatureClass(src, out_fc.rsplit('/', 1)[0], out_fc.rsplit('/', 1)[1])
+        out_fc_path = Path(out_fc)
+        arcpy.conversion.FeatureClassToFeatureClass(src, str(out_fc_path.parent), out_fc_path.name)
         logging.info(f"[STAGE] Imported GPKG {gpkg_path} -> {out_fc}")
         return True
     except Exception as e:

--- a/etl/stage_files.py
+++ b/etl/stage_files.py
@@ -1,0 +1,165 @@
+"""
+Simple, conservative ingestion of downloaded file-based sources into staging.gdb.
+
+Supports:
+- ZIP archives containing a single shapefile (or a named shapefile via `include` in sources)
+- GPKG files (imports first matching layer or named layer)
+- Single shapefile (.shp)
+
+Design: small, explicit rules; ambiguous archives are logged and skipped.
+"""
+from pathlib import Path
+import zipfile
+import logging
+import arcpy
+from .paths import staging_path
+
+
+def _find_latest_file(download_dir: Path, pattern: str):
+    # Find latest file matching a simple glob pattern (pattern can be '*' or name stem)
+    files = sorted(download_dir.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
+    return files[0] if files else None
+
+
+def _import_shapefile(shp_path: Path, cfg, out_name: str) -> bool:
+    out_fc = staging_path(cfg, out_name)
+    try:
+        # Remove existing target if present (overwrite behavior)
+        try:
+            if arcpy.Exists(out_fc):
+                arcpy.management.Delete(out_fc)
+        except Exception:
+            # best-effort delete; continue to attempt import
+            logging.debug(f"[STAGE] Could not delete existing {out_fc} before import")
+        arcpy.conversion.FeatureClassToFeatureClass(str(shp_path), out_fc.rsplit('/', 1)[0], out_fc.rsplit('/', 1)[1])
+        logging.info(f"[STAGE] Imported shapefile {shp_path} -> {out_fc}")
+        return True
+    except Exception as e:
+        logging.error(f"[STAGE] Failed to import shapefile {shp_path}: {e}")
+        return False
+
+
+def _import_gpkg(gpkg_path: Path, cfg, out_name: str, layer_name: str | None = None) -> bool:
+    out_fc = staging_path(cfg, out_name)
+    try:
+        # Remove existing target if present (overwrite behavior)
+        try:
+            if arcpy.Exists(out_fc):
+                arcpy.management.Delete(out_fc)
+        except Exception:
+            logging.debug(f"[STAGE] Could not delete existing {out_fc} before import")
+        if layer_name:
+            src = f"{str(gpkg_path)}|layername={layer_name}"
+        else:
+            # ArcPy can reference gpkg with layer syntax if needed; try to copy first layer
+            src = str(gpkg_path)
+        arcpy.conversion.FeatureClassToFeatureClass(src, out_fc.rsplit('/', 1)[0], out_fc.rsplit('/', 1)[1])
+        logging.info(f"[STAGE] Imported GPKG {gpkg_path} -> {out_fc}")
+        return True
+    except Exception as e:
+        logging.error(f"[STAGE] Failed to import GPKG {gpkg_path}: {e}")
+        return False
+
+
+def ingest_downloads(cfg: dict) -> None:
+    downloads = Path(cfg['workspaces']['downloads'])
+    for s in cfg.get('sources', []):
+        if not s.get('include', True):
+            continue
+        if s.get('type') not in ('file', 'http'):
+            continue
+
+        auth_dir = downloads / (s.get('authority') or '')
+        if not auth_dir.exists():
+            logging.debug(f"[STAGE] No download dir for {s.get('name')} ({auth_dir})")
+            continue
+
+        # Simple matching: look for files with source out_name or any standard extension
+        stem = s.get('out_name') or ''
+        include_hint = s.get('include')
+        # Also support a raw.layer_name override (preferred)
+        raw = s.get('raw') or {}
+        layer_hint = raw.get('layer_name') or raw.get('layer')
+
+        # normalize include_hint to a single string if possible, fallback to layer_hint
+        if isinstance(include_hint, list) and include_hint:
+            include_hint = include_hint[0]
+        if isinstance(include_hint, str):
+            include_hint = include_hint.strip()
+        else:
+            include_hint = None
+
+        if isinstance(layer_hint, list) and layer_hint:
+            layer_hint = layer_hint[0]
+        if isinstance(layer_hint, str):
+            layer_hint = layer_hint.strip()
+        else:
+            layer_hint = None
+
+        # Choose preferred hint: layer_hint first, then include_hint
+        preferred_hint = layer_hint or include_hint
+        candidates = []
+        # look for common extensions
+        for ext in ('*.zip', '*.gpkg', '*.shp'):
+            f = _find_latest_file(auth_dir, f"{stem}{ext}") or _find_latest_file(auth_dir, ext)
+            if f:
+                candidates.append(f)
+
+        if not candidates:
+            logging.info(f"[STAGE] No downloaded file found for source {s.get('name')} in {auth_dir}")
+            continue
+
+        file_path = candidates[0]
+        # handle zip
+        if file_path.suffix.lower() == '.zip':
+            try:
+                with zipfile.ZipFile(file_path, 'r') as zf:
+                    namelist = zf.namelist()
+                    shp_files = [n for n in namelist if n.lower().endswith('.shp')]
+                    gpkg_files = [n for n in namelist if n.lower().endswith('.gpkg')]
+                    # If include_hint points to a shapefile name, prefer that
+                    if preferred_hint:
+                        matched = [n for n in shp_files if preferred_hint.lower() in n.lower()]
+                        if matched:
+                            target_dir = file_path.with_suffix('')
+                            target_dir.mkdir(parents=True, exist_ok=True)
+                            zf.extractall(target_dir)
+                            shp_full = next(target_dir.glob(f"**/*{Path(matched[0]).name}"))
+                            _import_shapefile(shp_full, cfg, s['out_name'])
+                            continue
+
+                    if len(shp_files) == 1 and not gpkg_files:
+                        # extract the shapefile files (shp+shx+dbf etc.) to a temp dir
+                        target_dir = file_path.with_suffix('')
+                        target_dir.mkdir(parents=True, exist_ok=True)
+                        zf.extractall(target_dir)
+                        shp_full = next(target_dir.glob('**/*.shp'))
+                        _import_shapefile(shp_full, cfg, s['out_name'])
+                    elif len(gpkg_files) >= 1:
+                        # If include_hint names a gpkg layer (e.g. layername), extract and try to import that layer
+                        target_dir = file_path.with_suffix('')
+                        target_dir.mkdir(parents=True, exist_ok=True)
+                        zf.extractall(target_dir)
+                        gpkg_full = next(target_dir.glob('**/*.gpkg'))
+                        if layer_hint:
+                            _import_gpkg(gpkg_full, cfg, s['out_name'], layer_name=layer_hint)
+                        elif include_hint:
+                            _import_gpkg(gpkg_full, cfg, s['out_name'], layer_name=include_hint)
+                        else:
+                            _import_gpkg(gpkg_full, cfg, s['out_name'])
+                        continue
+                    else:
+                        logging.warning(f"[STAGE] Zip contains multiple or no shapefiles/gpkg; skipping {file_path}")
+            except Exception as e:
+                logging.error(f"[STAGE] Error extracting zip {file_path}: {e}")
+            continue
+
+        if file_path.suffix.lower() == '.gpkg':
+            _import_gpkg(file_path, cfg, s['out_name'])
+            continue
+
+        if file_path.suffix.lower() == '.shp':
+            _import_shapefile(file_path, cfg, s['out_name'])
+            continue
+
+        logging.info(f"[STAGE] Unsupported downloaded file type for {file_path}; skipping")

--- a/etl/stage_files.py
+++ b/etl/stage_files.py
@@ -44,7 +44,7 @@ def _import_shapefile(shp_path: Path, cfg, out_name: str) -> bool:
         return False
 
 
-def _import_gpkg(gpkg_path: Path, cfg, out_name: str, layer_name: str | None = None) -> bool:
+def _import_gpkg(gpkg_path: Path, cfg: dict, out_name: str, layer_name: str | None = None) -> bool:
     out_fc = staging_path(cfg, out_name)
     try:
         # Remove existing target if present (overwrite behavior)

--- a/etl/utils.py
+++ b/etl/utils.py
@@ -1,5 +1,81 @@
+"""Small ETL utilities used by staging and other modules.
+
+Keep these helpers minimal: choose best candidate by feature count.
+"""
+from pathlib import Path
 import logging
 import sys
+from typing import List, Optional
+
+
+def best_shapefile_by_count(paths: List[Path]) -> Optional[Path]:
+    """Return the Path with the highest feature count (>0) or None.
+
+    Imports ``arcpy`` inside the function so this module can be imported
+    in non-ArcPy environments for static analysis.
+    """
+    try:
+        import arcpy
+    except Exception:
+        logging.debug("[UTIL] arcpy not available; cannot count features")
+        return None
+
+    best: Optional[Path] = None
+    best_count = -1
+    for p in paths:
+        try:
+            res = arcpy.management.GetCount(str(p))
+            cnt = int(str(res.getOutput(0)))
+        except Exception as e:
+            logging.debug(f"[UTIL] GetCount failed for {p}: {e}")
+            cnt = -1
+        logging.debug(f"[UTIL] candidate {p} count={cnt}")
+        if cnt > best_count:
+            best_count = cnt
+            best = p
+
+    if best_count > 0:
+        return best
+    return None
+
+
+def best_layer_in_gpkg(gpkg_path: Path) -> Optional[str]:
+    """Return the layer name inside a GPKG with the highest feature count, or None.
+
+    Uses ArcPy to list feature classes inside the geopackage and selects the
+    layer with the largest feature count.
+    """
+    try:
+        import arcpy
+        import os
+    except Exception:
+        logging.debug("[UTIL] arcpy not available; cannot inspect GPKG")
+        return None
+    best: Optional[str] = None
+    best_count = -1
+    # Use da.Walk to enumerate feature classes inside the geopackage without
+    # changing the global arcpy.env.workspace.
+    try:
+        for dirpath, dirnames, filenames in arcpy.da.Walk(str(gpkg_path), datatype="FeatureClass"):
+            for fc in filenames:
+                # Build a workspace-resolved path for counting
+                candidate = os.path.join(dirpath, fc)
+                try:
+                    res = arcpy.management.GetCount(candidate)
+                    cnt = int(str(res.getOutput(0)))
+                except Exception as e:
+                    logging.debug(f"[UTIL] GetCount failed for {candidate}: {e}")
+                    cnt = -1
+                logging.debug(f"[UTIL] gpkg candidate {candidate} count={cnt}")
+                if cnt > best_count:
+                    best_count = cnt
+                    best = fc
+    except Exception as e:
+        logging.debug(f"[UTIL] da.Walk failed for {gpkg_path}: {e}")
+
+    if best_count > 0:
+        return best
+    return None
 
 
 def get_logger() -> logging.Logger:
@@ -17,7 +93,7 @@ def get_logger() -> logging.Logger:
     return log
 
 
-def log_http_request(log, session, method, url, **kwargs):
+def log_http_request(log: logging.Logger, session, method: str, url: str, **kwargs):
     log.info("[HTTP] start method=%s url=%s", method, url)
     response = session.request(method, url, **kwargs)
     log.info("[HTTP] done  method=%s status=%d url=%s", method, response.status_code, url)

--- a/run.py
+++ b/run.py
@@ -43,6 +43,9 @@ def main():
         from etl import download_http, download_rest
         download_http.run(cfg)
         download_rest.run(cfg)
+        # Ingest downloaded file-based sources into staging.gdb
+        from etl import stage_files
+        stage_files.ingest_downloads(cfg)
         logging.info("Download process finished.")
 
     if args.process or do_all:


### PR DESCRIPTION
## Summary by Sourcery

Implement utilities and workflow enhancements for file-based ETL: add ArcPy-based helpers, improve HTTP download reliability, update configuration paths, and introduce a staging module to ingest downloaded ZIP, GPKG, and shapefile data into the staging geodatabase

New Features:
- Add best_shapefile_by_count and best_layer_in_gpkg helpers for selecting ArcPy feature layers by count
- Introduce etl/stage_files module to ingest downloaded ZIP, GPKG, and shapefile sources into staging geodatabase

Enhancements:
- Enhance http_download with exponential backoff retries, atomic .part file writes, and non-empty file validation
- Treat 'file' source type like HTTP in download workflow and add 'atom_feed' placeholder handler
- Update default workspace and file path settings in config.yaml to use a .data directory structure
- Add graceful skip and warning when source features are missing in load_sde
- Integrate stage_files.ingest_downloads into run pipeline after HTTP and REST downloads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added automatic ingestion of downloaded files into the staging geodatabase, supporting ZIP (shapefiles) and GeoPackage, with smart layer/file selection.
  - Pipeline now runs the ingestion step after downloads.
- Improvements
  - More reliable downloads with atomic writes, validation, and retry with backoff.
  - Supports local file sources in the download step.
  - Standardized data and logs under hidden .data/.logs directories; .data is now ignored by Git.
- Bug Fixes
  - Skip and warn when a staging source is missing instead of failing.
- Chores
  - VS Code: default test runner switched to pytest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->